### PR TITLE
use mutate from SWRConfiguration context

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import { TRPCClient, TRPCClientErrorLike, TRPCRequestOptions } from '@trpc/client'
 import { AnyRouter, inferHandlerInput } from '@trpc/server'
 import React from 'react'
-import _useSWR, { Key, mutate as mutateSWR, MutatorOptions, SWRConfiguration, SWRResponse, useSWRConfig } from 'swr'
+import _useSWR, { Key, MutatorOptions, SWRConfiguration, SWRResponse, useSWRConfig } from 'swr'
 import { TRPCContext, TRPCContextState } from './context'
 import { inferProcedures, WrapPromiseAndMutatorCallback } from './types'
 import { getClientArgs } from './utils'
@@ -19,13 +19,13 @@ export function createSWRHooks<TRouter extends AnyRouter>() {
     client: TRPCClient<TRouter>
     children: React.ReactNode
   }) => {
+    const { mutate } = useSWRConfig()
+
     return (
       <Context.Provider
         value={{
           client,
-          mutate(pathAndInput, data, opts) {
-            return mutateSWR(pathAndInput, data, opts)
-          },
+          mutate,
         }}
       >
         {children}


### PR DESCRIPTION
Currently `createSWRHooks` is limited to use of the global `swr` config (state/cache) which prevents us from being able to correctly make use of `<SWRConfig />` since mutations would always apply to the global state rather than context state (where we'd be reading from). `getUseMatchMutate` already operates correctly on the config provided by the nearest context.

This change updates `TRPCProvider` to use `useSWRConfig().mutate`, which operates on the context state (where context is available) or falls back to global state.