### PR TITLE
fix: export infinite types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,13 @@
 	"license": "MIT",
 	"main": "dist/index.cjs",
 	"types": "dist/index.d.ts",
+	"typesVersions": {
+		"*": {
+			"infinite": [
+				"dist/infinite.d.ts"
+			]
+		}
+	},
 	"exports": {
 		"./package.json": "./package.json",
 		".": {


### PR DESCRIPTION
Following issue #11, I added the `trpc-swr/infinite` types in the package.json